### PR TITLE
fix-uid

### DIFF
--- a/lib/omniauth/strategies/mastodon.rb
+++ b/lib/omniauth/strategies/mastodon.rb
@@ -10,13 +10,14 @@ module OmniAuth
       option :credentials
       option :identifier
       option :authorize_options, [:scope]
+      option :domain
 
       option :client_options, {
         authorize_url: '/oauth/authorize',
         token_url: '/oauth/token'
       }
 
-      uid { identifier }
+      uid { extra.raw_info['id'] }
 
       info do
         {


### PR DESCRIPTION
`uid` should be given by system, but it is user-inputed text.

For example, if a user input `Gargron@mastodon.social` as identifier,
he was authenticated by his own user `a_user@mastodon.social`,
but `uid` is yet `Gargron@mastodon.social`.

I think `uid` should be built from `raw_info`.
( `raw_info['id']` is temporary value )