### PR TITLE
Add i18n locale

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,37 @@
 PATH
   remote: .
   specs:
-    omniauth-mastodon (0.0.1)
+    omniauth-mastodon (0.9.3)
+      i18n (~> 0.7)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    faraday (0.9.2)
+    concurrent-ruby (1.0.5)
+    faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
-    hashie (3.4.6)
+    hashie (3.5.7)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     jwt (1.5.6)
-    multi_json (1.12.1)
-    multi_xml (0.5.5)
+    multi_json (1.13.1)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
-    oauth2 (1.2.0)
-      faraday (>= 0.8, < 0.10)
+    oauth2 (1.4.0)
+      faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.3.1)
-      hashie (>= 1.2, < 4)
-      rack (>= 1.0, < 3)
-    omniauth-oauth2 (1.4.0)
-      oauth2 (~> 1.0)
+    omniauth (1.8.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-oauth2 (1.5.0)
+      oauth2 (~> 1.1)
       omniauth (~> 1.2)
-    rack (2.0.1)
+    rack (2.0.5)
 
 PLATFORMS
   ruby
@@ -37,4 +41,4 @@ DEPENDENCIES
   omniauth-mastodon!
 
 BUNDLED WITH
-   1.13.0
+   1.16.4

--- a/lib/omniauth-mastodon.rb
+++ b/lib/omniauth-mastodon.rb
@@ -1,2 +1,5 @@
+require 'i18n'
+I18n.load_path += Dir[File.expand_path('../omniauth/mastodon/locale/*.yml', __FILE__)]
+
 require 'omniauth/mastodon/version'
 require 'omniauth/strategies/mastodon'

--- a/lib/omniauth/mastodon/locale/en.yml
+++ b/lib/omniauth/mastodon/locale/en.yml
@@ -1,0 +1,6 @@
+en:
+  omniauth:
+    mastodon:
+      title: 'Mastodon Login'
+      text: 'Your full Mastodon identifier (username@domain)'
+      button: 'Login'

--- a/lib/omniauth/mastodon/locale/ja.yml
+++ b/lib/omniauth/mastodon/locale/ja.yml
@@ -1,0 +1,6 @@
+ja:
+  omniauth:
+    mastodon:
+      title: 'Mastodon ログイン'
+      text: 'ドメインを含めたIDを入力してください (例: username@domain)'
+      button: 'ログイン'

--- a/lib/omniauth/strategies/mastodon.rb
+++ b/lib/omniauth/strategies/mastodon.rb
@@ -60,10 +60,22 @@ module OmniAuth
       private
 
       def get_identifier
-        form = OmniAuth::Form.new(title: 'Mastodon Login')
-        form.text_field 'Your full Mastodon identifier (username@domain)', 'identifier'
-        form.button 'Login'
-        form.to_response
+        I18n.with_locale(locale) do
+          form = OmniAuth::Form.new(title: translate('.omniauth.mastodon.title'))
+          form.text_field translate('.omniauth.mastodon.text'), 'identifier'
+          form.button translate('.omniauth.mastodon.button')
+          form.to_response
+        end
+      end
+
+      def translate(t)
+        I18n.exists?(t) ? I18n.t(t) : I18n.t(t, locale: :en)
+      end
+
+      def locale
+        loc = request.params['locale'] || session[:omniauth_login_locale] || I18n.default_locale
+        loc = :en unless I18n.locale_available?(loc)
+        loc
       end
 
       def start_oauth

--- a/omniauth-mastodon.gemspec
+++ b/omniauth-mastodon.gemspec
@@ -9,13 +9,14 @@ Gem::Specification.new do |spec|
   spec.summary       = spec.description
   spec.homepage      = "https://github.com/tootsuite/omniauth-mastodon"
   spec.licenses      = %w(MIT)
-  spec.files         = %w(omniauth-mastodon.gemspec) + Dir['lib/**/*.rb']
+  spec.files         = %w(omniauth-mastodon.gemspec) + Dir['lib/**/*.rb'] + Dir['lib/**/*.yml']
   spec.name          = "omniauth-mastodon"
   spec.require_paths = %w(lib)
   spec.version       = OmniAuth::Mastodon::Version
 
   spec.add_dependency 'omniauth', '~> 1.0'
   spec.add_dependency 'omniauth-oauth2', '~> 1.1'
+  spec.add_dependency 'i18n', '~> 0.7'
 
   spec.add_development_dependency 'bundler', '~> 1.0'
 end


### PR DESCRIPTION
Hi, Gargron.

I add I18n translation to omniauth-mastodon. (currently EN and JP)
 
* EN ( already exists )
![screen shot 2018-10-30 at 22 42 07](https://user-images.githubusercontent.com/573880/47722153-0fe98480-dc95-11e8-84a5-fe5b3fa83062.png)

* JP ( add new language )
![screen shot 2018-10-30 at 22 41 54](https://user-images.githubusercontent.com/573880/47722203-2c85bc80-dc95-11e8-9736-2a82f6487df2.png)

please merge it if you like.

Thanks.